### PR TITLE
Change params class to have single static copy of itself

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,12 +13,12 @@ AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -5,7 +5,6 @@
 #include <string>
 
 #include "Config.h"
-#include "Version.h"
 
 namespace logging {
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -7,26 +7,6 @@
 
 namespace parameters {
 
-<<<<<<< HEAD
-  // First initialisation of static params
-
-  // Talking related parameters
-  // --------------------------
-  int Parameters::_nstepsLog = 0;
-
-  // simulation related parameters
-  // -----------------------------
-  int   Parameters::_nsteps = 0;
-  float Parameters::_tmax   = 0;
-
-  int   Parameters::_nx   = 100;
-  float Parameters::_ccfl = 0.9;
-  // float Parameters::_forceDt = 0;
-  int Parameters::_boundary = 0;
-
-  int   Parameters::_nxTot = 100 + BCTOT;
-  float Parameters::_dx    = BOXLEN / _nx;
-=======
     // need to define it as well...
     Parameters Parameters::Instance;
 
@@ -34,9 +14,9 @@ namespace parameters {
     _nstepsLog(0), _nsteps(0),
     _tmax(0), _nx(100),
     _ccfl(0.9), _boundary(0),
-    _nxTot(100 + BCTOT), _dx(BOXLEN / _nx)
+    _nxTot(100 + BCTOT),
+    _dx(BOXLEN / _nx)
     {/* empty body */}
->>>>>>> d71bc8a (change the parameters class to contain a single static copy of itself to hold global variables)
 
 
   // output related parameters

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -7,6 +7,7 @@
 
 namespace parameters {
 
+<<<<<<< HEAD
   // First initialisation of static params
 
   // Talking related parameters
@@ -25,6 +26,17 @@ namespace parameters {
 
   int   Parameters::_nxTot = 100 + BCTOT;
   float Parameters::_dx    = BOXLEN / _nx;
+=======
+    // need to define it as well...
+    Parameters Parameters::Instance;
+
+    Parameters::Parameters() :
+    _nstepsLog(0), _nsteps(0),
+    _tmax(0), _nx(100),
+    _ccfl(0.9), _boundary(0),
+    _nxTot(100 + BCTOT), _dx(BOXLEN / _nx)
+    {/* empty body */}
+>>>>>>> d71bc8a (change the parameters class to contain a single static copy of itself to hold global variables)
 
 
   // output related parameters

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -7,16 +7,18 @@
 
 namespace parameters {
 
-    // need to define it as well...
-    Parameters Parameters::Instance;
+  // need to define it as well...
+  Parameters Parameters::Instance;
 
-    Parameters::Parameters() :
-    _nstepsLog(0), _nsteps(0),
-    _tmax(0), _nx(100),
-    _ccfl(0.9), _boundary(0),
+  Parameters::Parameters():
+    _nstepsLog(0),
+    _nsteps(0),
+    _tmax(0),
+    _nx(100),
+    _ccfl(0.9),
+    _boundary(0),
     _nxTot(100 + BCTOT),
-    _dx(BOXLEN / _nx)
-    {/* empty body */}
+    _dx(BOXLEN / _nx) { /* empty body */ }
 
 
   // output related parameters

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -1,4 +1,5 @@
 #include "Parameters.h"
+#include "Logging.h"
 
 
 // TODO: These definitions are temporary and need to go.
@@ -10,15 +11,16 @@ namespace parameters {
   // need to define it as well...
   Parameters Parameters::Instance;
 
-  Parameters::Parameters():
+  Parameters::Parameters() :
+    _verbose(logging::LogLevel::Quiet),
     _nstepsLog(0),
     _nsteps(0),
-    _tmax(0),
-    _nx(100),
-    _ccfl(0.9),
+    _tmax(0.),
+    _nx(0),
+    _ccfl(0.),
     _boundary(0),
-    _nxTot(100 + BCTOT),
-    _dx(BOXLEN / _nx) { /* empty body */ }
+    _nxTot(0),
+    _dx(0.) { /* empty body */ }
 
 
   // output related parameters
@@ -51,44 +53,77 @@ namespace parameters {
   // _constant_acceleration_computed = 0;
   // _sources_are_read = 0;
 
-  /**
-   * Initialize parameters to default values
-   */
-  void Parameters::init() {
-    // TODO
+
+  logging::LogLevel Parameters::getVerbose() const {
+    return _verbose;
   }
 
-  int Parameters::getNstepsLog() { return _nstepsLog; }
+  void Parameters::setVerbose(const logging::LogLevel logLevel){
+    _verbose = logLevel;
+  }
 
-  void Parameters::setNstepsLog(const int nstepsLog) { _nstepsLog = nstepsLog; }
 
-  int Parameters::getNsteps() { return _nsteps; }
+  int Parameters::getNstepsLog() const {
+    return _nstepsLog;
+  }
 
-  void Parameters::setNsteps(const int nsteps) { _nsteps = nsteps; }
+  void Parameters::setNstepsLog(const int nstepsLog) {
+    _nstepsLog = nstepsLog;
+  }
 
-  float Parameters::getTmax() { return _tmax; }
+  int Parameters::getNsteps() const {
+    return _nsteps;
+  }
 
-  void Parameters::setTmax(const float tmax) { _tmax = tmax; }
+  void Parameters::setNsteps(const int nsteps) {
+    _nsteps = nsteps;
+  }
 
-  int Parameters::getNx() { return _nx; }
+  float_t Parameters::getTmax() const {
+    return _tmax;
+  }
 
-  void Parameters::setNx(const int nx) { _nx = nx; }
+  void Parameters::setTmax(const float tmax) {
+    _tmax = tmax;
+  }
 
-  float Parameters::getCcfl() { return _ccfl; }
+  int Parameters::getNx() const {
+    return _nx;
+  }
 
-  void Parameters::setCcfl(const float ccfl) { _ccfl = ccfl; }
+  void Parameters::setNx(const int nx) {
+    _nx = nx;
+  }
 
-  int Parameters::getBoundary() { return _boundary; }
+  float_t Parameters::getCcfl() const {
+    return _ccfl;
+  }
 
-  void Parameters::setBoundary(const int boundary) { _boundary = boundary; }
+  void Parameters::setCcfl(const float ccfl) {
+    _ccfl = ccfl;
+  }
 
-  int Parameters::getNxTot() { return _nxTot; }
+  int Parameters::getBoundary() const {
+    return _boundary;
+  }
+
+  void Parameters::setBoundary(const int boundary) {
+    _boundary = boundary;
+  }
+
+  int Parameters::getNxTot() const {
+    return _nxTot;
+  }
 
   void Parameters::setNxTot(const int nxTot) { _nxTot = nxTot; }
 
-  float Parameters::getDx() { return _dx; }
+  float_t Parameters::getDx() const {
+    return _dx;
+  }
 
-  void Parameters::setDx(const float dx) { _dx = dx; }
+  void Parameters::setDx(const float_t dx) {
+    _dx = dx;
+  }
 
 
 } // namespace parameters

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "Config.h"
+#include "Logging.h"
+
 /*
 
 Turning this class into singleton pattern. In any file where you
@@ -28,26 +31,26 @@ namespace parameters {
     // --------------------------
 
     //! how verbose are we?
-    // int _verbose;
+    logging::LogLevel verbose;
 
     //! interval between steps to write current state to screen
-    int _nstepsLog;
+    int nstepsLog;
 
 
     // simulation related parameters
     // -----------------------------
 
     //! How many steps to do
-    int _nsteps;
+    int nsteps;
 
     //! at what time to end simulation
-    float _tmax;
+    double tmax;
 
     //! number of cells to use (in each dimension)
-    int _nx;
+    int nx;
 
     //! CFL coefficient
-    float _ccfl;
+    float_t ccfl;
 
     //! boundary condition
     int _boundary;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -1,5 +1,23 @@
 #pragma once
 
+/*
+
+Turning this class into singleton pattern. In any file where you
+include Parameters.h, you can call
+hydro_playground::parameters::Parameters::Instance._nstepsLog (for example)
+and it will be this single global copy.
+
+Since the member variables are nonstatic now i've un-deleted the default
+constructor. This will be called by default on the static member anyhow
+
+We could remove the namespaceing
+here as it is a bit of a mouthful to type...
+
+It's up to us whether we make the instance itself private and use the
+getter or just make it public. It doesn't make a difference, since we
+need to return a reference anyway...
+
+*/
 
 namespace parameters {
 
@@ -12,36 +30,33 @@ namespace parameters {
     //! how verbose are we?
     // int _verbose;
 
-    //! interval between steps to write current state to screen
-    static int _nstepsLog;
+      //! interval between steps to write current state to screen
+      int _nstepsLog;
 
 
     // simulation related parameters
     // -----------------------------
 
-    //! How many steps to do
-    static int _nsteps;
+      //! How many steps to do
+      int _nsteps;
 
-    //! at what time to end simulation
-    static float _tmax;
+      //! at what time to end simulation
+      float _tmax;
 
-    //! number of cells to use (in each dimension)
-    static int _nx;
+      //! number of cells to use (in each dimension)
+      int _nx;
 
-    //! CFL coefficient
-    static float _ccfl;
+      //! CFL coefficient
+      float _ccfl;
 
-    //! time step sized used when enforcing a fixed time step size
-    // float _force_dt;
+      //! boundary condition
+      int _boundary;
 
-    //! boundary condition
-    static int _boundary;
+      //! number of mesh points, including boundary cells
+      int _nxTot;
 
-    //! number of mesh points, including boundary cells
-    static int _nxTot;
-
-    //! cell size
-    static float _dx;
+      //! cell size
+      float _dx;
 
 
     // Output related parameters
@@ -107,37 +122,45 @@ namespace parameters {
     // int _sources_are_read;
 
 
-  public:
-    Parameters() = delete;
+    public:
+      Parameters();
 
-    static void init();
+      void init();
 
-    static void cleanup();
+      void cleanup();
 
-    static int  getNstepsLog();
-    static void setNstepsLog(const int nsteps_log);
+      int  getNstepsLog();
+      void setNstepsLog(const int nsteps_log);
 
-    static int  getNsteps();
-    static void setNsteps(const int nsteps);
+      int  getNsteps();
+      void setNsteps(const int nsteps);
 
-    static float getTmax();
-    static void  setTmax(const float tmax);
+      float getTmax();
+      void  setTmax(const float tmax);
 
-    static int  getNx();
-    static void setNx(const int nx);
+      int  getNx();
+      void setNx(const int nx);
 
-    static float getCcfl();
-    static void  setCcfl(float ccfl);
+      float getCcfl();
+      void  setCcfl(float ccfl);
 
-    static int  getBoundary();
-    static void setBoundary(const int boundary);
+      int  getBoundary();
+      void setBoundary(const int boundary);
 
-    static int  getNxTot();
-    static void setNxTot(const int nxTot);
+      int  getNxTot();
+      void setNxTot(const int nxTot);
 
-    static float getDx();
-    static void  setDx(const float dx);
-  };
+      float getDx();
+      void  setDx(const float dx);
+
+    public:
+
+      // single copy of the global variables
+      static Parameters Instance;
+
+      // getter for the single global copy
+      static Parameters& getInstance() {return Instance;}
+    };
 
 
 } // namespace parameters

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -26,40 +26,42 @@ namespace parameters {
 
   class Parameters {
 
-  private:
     // Talking related parameters
     // --------------------------
 
+  private:
+
     //! how verbose are we?
-    logging::LogLevel verbose;
+    logging::LogLevel _verbose;
 
     //! interval between steps to write current state to screen
-    int nstepsLog;
+    int _nstepsLog;
 
 
     // simulation related parameters
     // -----------------------------
 
     //! How many steps to do
-    int nsteps;
+    int _nsteps;
 
     //! at what time to end simulation
-    double tmax;
+    float_t _tmax;
 
     //! number of cells to use (in each dimension)
-    int nx;
+    int _nx;
 
     //! CFL coefficient
-    float_t ccfl;
+    float_t _ccfl;
 
     //! boundary condition
+    // TODO(mivkov): Make enum
     int _boundary;
 
     //! number of mesh points, including boundary cells
     int _nxTot;
 
     //! cell size
-    float _dx;
+    float_t _dx;
 
 
     // Output related parameters
@@ -69,7 +71,7 @@ namespace parameters {
     // int _foutput;
 
     //! time interval between outputs
-    // float _dt_out;
+    // double _dt_out;
 
     //! Output file name basename
     // char _outputfilename[MAX_FNAME_SIZE];
@@ -78,7 +80,7 @@ namespace parameters {
     // char _toutfilename[MAX_FNAME_SIZE];
 
     //! whether we're using the t_out_file
-    // int _use_toutfile;
+    // bool _use_toutfile;
 
     //! how many outputs we will be writing. Only used if(use_toutfile)
     // int _noutput_tot;
@@ -87,7 +89,7 @@ namespace parameters {
     // int _noutput;
 
     //! array of output times given in the output file
-    // float *_outputtimes;
+    // float_t _*outputtimes;
 
 
     // IC related parameters
@@ -107,56 +109,57 @@ namespace parameters {
     // --------------------------
 
     //! constant acceleration in x direction for constant source terms
-    // float _src_const_acc_x;
+    // float_t _src_const_acc_x;
 
     //! constant acceleration in y direction for constant source terms
-    // float _src_const_acc_y;
+    // float_t _src_const_acc_y;
 
     //! constant acceleration in radial direction for radial source terms
-    // float _src_const_acc_r;
+    // float_t _src_const_acc_r;
 
     //! whether the sources will be constant
-    // int _constant_acceleration;
+    // bool _constant_acceleration;
 
     //! whether the constant acceleration has been computed
-    // int _constant_acceleration_computed;
+    // bool _constant_acceleration_computed;
 
     //! whether sources have been read in
-    // int _sources_are_read;
+    // bool _sources_are_read;
 
 
   public:
     Parameters();
 
-    void init();
-
+    // ToDo: Move in destructor
     void cleanup();
 
-    int  getNstepsLog();
-    void setNstepsLog(const int nsteps_log);
+    logging::LogLevel getVerbose() const;
+    void setVerbose(const logging::LogLevel logLevel);
 
-    int  getNsteps();
+    int  getNstepsLog() const;
+    void setNstepsLog(const int nstepsLog);
+
+    int  getNsteps() const;
     void setNsteps(const int nsteps);
 
-    float getTmax();
-    void  setTmax(const float tmax);
+    float_t getTmax() const;
+    void setTmax(const float_t tmax);
 
-    int  getNx();
+    int  getNx() const;
     void setNx(const int nx);
 
-    float getCcfl();
-    void  setCcfl(float ccfl);
+    float_t getCcfl() const;
+    void  setCcfl(float_t ccfl);
 
-    int  getBoundary();
+    int  getBoundary() const;
     void setBoundary(const int boundary);
 
-    int  getNxTot();
+    int  getNxTot() const;
     void setNxTot(const int nxTot);
 
-    float getDx();
-    void  setDx(const float dx);
+    float_t getDx() const;
+    void  setDx(const float_t dx);
 
-  public:
     // single copy of the global variables
     static Parameters Instance;
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -30,33 +30,33 @@ namespace parameters {
     //! how verbose are we?
     // int _verbose;
 
-      //! interval between steps to write current state to screen
-      int _nstepsLog;
+    //! interval between steps to write current state to screen
+    int _nstepsLog;
 
 
     // simulation related parameters
     // -----------------------------
 
-      //! How many steps to do
-      int _nsteps;
+    //! How many steps to do
+    int _nsteps;
 
-      //! at what time to end simulation
-      float _tmax;
+    //! at what time to end simulation
+    float _tmax;
 
-      //! number of cells to use (in each dimension)
-      int _nx;
+    //! number of cells to use (in each dimension)
+    int _nx;
 
-      //! CFL coefficient
-      float _ccfl;
+    //! CFL coefficient
+    float _ccfl;
 
-      //! boundary condition
-      int _boundary;
+    //! boundary condition
+    int _boundary;
 
-      //! number of mesh points, including boundary cells
-      int _nxTot;
+    //! number of mesh points, including boundary cells
+    int _nxTot;
 
-      //! cell size
-      float _dx;
+    //! cell size
+    float _dx;
 
 
     // Output related parameters
@@ -122,45 +122,44 @@ namespace parameters {
     // int _sources_are_read;
 
 
-    public:
-      Parameters();
+  public:
+    Parameters();
 
-      void init();
+    void init();
 
-      void cleanup();
+    void cleanup();
 
-      int  getNstepsLog();
-      void setNstepsLog(const int nsteps_log);
+    int  getNstepsLog();
+    void setNstepsLog(const int nsteps_log);
 
-      int  getNsteps();
-      void setNsteps(const int nsteps);
+    int  getNsteps();
+    void setNsteps(const int nsteps);
 
-      float getTmax();
-      void  setTmax(const float tmax);
+    float getTmax();
+    void  setTmax(const float tmax);
 
-      int  getNx();
-      void setNx(const int nx);
+    int  getNx();
+    void setNx(const int nx);
 
-      float getCcfl();
-      void  setCcfl(float ccfl);
+    float getCcfl();
+    void  setCcfl(float ccfl);
 
-      int  getBoundary();
-      void setBoundary(const int boundary);
+    int  getBoundary();
+    void setBoundary(const int boundary);
 
-      int  getNxTot();
-      void setNxTot(const int nxTot);
+    int  getNxTot();
+    void setNxTot(const int nxTot);
 
-      float getDx();
-      void  setDx(const float dx);
+    float getDx();
+    void  setDx(const float dx);
 
-    public:
+  public:
+    // single copy of the global variables
+    static Parameters Instance;
 
-      // single copy of the global variables
-      static Parameters Instance;
-
-      // getter for the single global copy
-      static Parameters& getInstance() {return Instance;}
-    };
+    // getter for the single global copy
+    static Parameters& getInstance() { return Instance; }
+  };
 
 
 } // namespace parameters

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,11 @@
 
 
 #include <iostream> // todo: necessary?
+#include <sstream>
 
 #include "Config.h" // todo: necessary?
-#include "Gas.h"    // probably not necessary. wanna catch compile errors
-#include "Logging.h"
+// #include "Gas.h"    // probably not necessary. wanna catch compile errors
+// #include "Logging.h"
 #include "Parameters.h"
 #include "Utils.h"
 
@@ -15,6 +16,9 @@ int main(void) {
   utils::print_header();
 
   // Initialise global paramters.
-  parameters::Parameters::Instance.init();
+  auto params = parameters::Parameters::Instance;
+  std::ostringstream msg;
+  msg << "Got params dx=" << params.getDx();
+  message(msg.str());
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,6 @@ int main(void) {
   utils::print_header();
 
   // Initialise global paramters.
-  parameters::Parameters::init();
-
+  parameters::Parameters::Instance.init();
   return 0;
 }


### PR DESCRIPTION
Change the params class to use more of a c++ style - reintroduced the standard constructor which is called in the definition of the static instance. Example of how to call it is in main.cpp.

Marking as draft until my other one is reviewed.