### PR TITLE
Removed usage of vectors for boundary conditions and added option to enable address sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,16 @@ message("* Current build type is : ${CMAKE_BUILD_TYPE}")
 # Options
 # ---------------------------
 
+
+option(SANITIZER "Enable address sanitizers" OFF)
+if (SANITIZER)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+endif(SANITIZER)
+
+message(STATUS "SANITIZER is set to: ${SANITIZER}")
+
+
 # Terminal colours
 
 option(TERMINAL_COLORS "Enable colour logging outputs" OFF)

--- a/doc/rtd/source/conf.py
+++ b/doc/rtd/source/conf.py
@@ -6,23 +6,22 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Hydro-Playground Parallelisation'
-copyright = '2025, Mladen Ivkovic, Will J. Roper'
-author = 'Mladen Ivkovic, Will J. Roper'
-release = '1.0'
+project = "Hydro-Playground Parallelisation"
+copyright = "2025, Mladen Ivkovic, Will J. Roper"
+author = "Mladen Ivkovic, Will J. Roper"
+release = "1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -1,0 +1,101 @@
+#include "BoundaryConditions.h"
+
+/**
+ * Apply the periodic boundary conditions.
+ *
+ * @param realL:     array of pointers to real cells with lowest index
+ * @param realR:     array of pointers to real cells with highest index
+ * @param ghostL:    array of pointers to ghost cells with lowest index
+ * @param ghostR:    array of pointers to ghost cells with highest index
+ * @param nbc:       number of boundary cells.
+ * @param dimension: dimension integer. 0 for x, 1 for y. Needed for
+ *                   reflective boundary conditions.
+ */
+void BC::periodic(
+  Boundary&    real_left,
+  Boundary&    real_right,
+  Boundary&    ghost_left,
+  Boundary&    ghost_right,
+  const size_t nbc,
+  const size_t dimension
+) {
+
+#if DEBUG_LEVEL > 0
+  assert(real_left.size() == nbc);
+  assert(real_right.size() == nbc);
+  assert(ghost_left.size() == nbc);
+  assert(ghost_right.size() == nbc);
+#endif
+
+  for (size_t i = 0; i < nbc; i++) {
+    ghost_left[i]->copyBoundaryData(real_right[i]);
+    ghost_right[i]->copyBoundaryData(real_left[i]);
+  }
+}
+
+
+/**
+ * Apply the reflective boundary conditions.
+ *
+ * @param realL:     array of pointers to real cells with lowest index
+ * @param realR:     array of pointers to real cells with highest index
+ * @param ghostL:    array of pointers to ghost cells with lowest index
+ * @param ghostR:    array of pointers to ghost cells with highest index
+ * @param nbc:       number of boundary cells.
+ * @param dimension: dimension integer. 0 for x, 1 for y. Needed for
+ *                   reflective boundary conditions.
+ */
+void BC::reflective(
+  Boundary&    real_left,
+  Boundary&    real_right,
+  Boundary&    ghost_left,
+  Boundary&    ghost_right,
+  const size_t nbc,
+  const size_t dimension
+) {
+
+#if DEBUG_LEVEL > 0
+  assert(real_left.size() == nbc);
+  assert(real_right.size() == nbc);
+  assert(ghost_left.size() == nbc);
+  assert(ghost_right.size() == nbc);
+#endif
+
+  for (size_t i = 0; i < nbc; i++) {
+    ghost_left[i]->copyBoundaryDataReflective(real_left[real_left.size() - i - 1], dimension);
+    ghost_right[i]->copyBoundaryDataReflective(real_right[real_right.size() - i - 1], dimension);
+  }
+}
+
+
+/**
+ * Apply the transmissive boundary conditions.
+ *
+ * @param realL:     array of pointers to real cells with lowest index
+ * @param realR:     array of pointers to real cells with highest index
+ * @param ghostL:    array of pointers to ghost cells with lowest index
+ * @param ghostR:    array of pointers to ghost cells with highest index
+ * @param nbc:       number of boundary cells.
+ * @param dimension: dimension integer. 0 for x, 1 for y. Needed for
+ *                   reflective boundary conditions.
+ */
+void BC::transmissive(
+  Boundary&    real_left,
+  Boundary&    real_right,
+  Boundary&    ghost_left,
+  Boundary&    ghost_right,
+  const size_t nbc,
+  const size_t dimension
+) {
+
+#if DEBUG_LEVEL > 0
+  assert(real_left.size() == nbc);
+  assert(real_right.size() == nbc);
+  assert(ghost_left.size() == nbc);
+  assert(ghost_right.size() == nbc);
+#endif
+  for (size_t i = 0; i < nbc; i++) {
+    ghost_left[i]->copyBoundaryData(real_left[real_left.size() - i - 1]);
+    ghost_right[i]->copyBoundaryData(real_right[real_right.size() - i - 1]);
+  }
+}

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <cstddef>
-#include <utility>
 #include <string>
+#include <utility>
 
 #include "Cell.h"
 
@@ -51,47 +51,50 @@ namespace BC {
  * e.g. openMP offloading is not happy about. So I write proper constructors
  * by myself.
  */
-class Boundary{
+class Boundary {
 
 public:
-
   size_t _n;
   Cell** _cells;
 
-  explicit Boundary(const size_t N) : _n(N), _cells(new Cell*[N]) {};
+  explicit Boundary(const size_t N):
+    _n(N),
+    _cells(new Cell*[N]) {};
 
   ~Boundary() {
     delete[] _cells;
   }
 
   // Copy operator
-  Boundary(const Boundary& other) : _n(other._n) {
+  Boundary(const Boundary& other):
+    _n(other._n) {
     for (size_t i = 0; i < _n; i++)
       _cells[i] = other._cells[i];
   }
 
   // Copy assignment
   Boundary& operator=(const Boundary& other) {
-    this->_n= other._n;
+    this->_n = other._n;
     for (size_t i = 0; i < _n; i++)
       this->_cells[i] = other._cells[i];
     return *this;
   }
 
   // Move operator
-  Boundary(const Boundary&& other)  noexcept : _n(other._n) {
+  Boundary(const Boundary&& other) noexcept:
+    _n(other._n) {
     _cells = std::move(other._cells);
   }
 
   // Move assignment
   Boundary& operator=(Boundary&& other) noexcept {
-    this->_n= other._n;
+    this->_n     = other._n;
     this->_cells = other._cells;
     return *this;
   }
 
   // overload [] operator
-  Cell*& operator[](size_t index){
+  Cell*& operator[](size_t index) {
 #if DEBUG_LEVEL > 0
     if (index > _n)
       error("Invalid index:" + std::to_string(index));
@@ -99,9 +102,7 @@ public:
     return _cells[index];
   }
 
-  size_t size(){
+  size_t size() {
     return _n;
   }
 };
-
-

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -46,17 +46,21 @@ namespace BC {
 
 
 /**
- * A simple container for boundary cells. You can in principle just use a list
- * or a vector, but those STL objects are not trivially copyable - something
- * e.g. openMP offloading is not happy about. So I write proper constructors
- * by myself.
+ * A simple container for boundary cells. Just think of it as an array of
+ * pointers to cells.
+ *
+ * I added this trying to avoid "<data type> is not trivially copyable and not
+ * guaranteed to be mapped correctly" warnings with OpenMP offloading, but this
+ * didn't really solve it. But it lets us avoid std::vectors and is simple enough,
+ * so let's keep it for now.
  */
 class Boundary {
 
-public:
+private:
   size_t _n;
   Cell** _cells;
 
+public:
   explicit Boundary(const size_t N):
     _n(N),
     _cells(new Cell*[N]) {};
@@ -93,7 +97,7 @@ public:
     return *this;
   }
 
-  // overload [] operator
+  // overload [] operator for access
   Cell*& operator[](size_t index) {
 #if DEBUG_LEVEL > 0
     if (index > _n)
@@ -102,6 +106,9 @@ public:
     return _cells[index];
   }
 
+  /**
+   * Get the size of the cell pointer array.
+   */
   size_t size() {
     return _n;
   }

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -5,6 +5,13 @@
 
 #pragma once
 
+#include <cstddef>
+#include <utility>
+#include <string>
+
+#include "Cell.h"
+
+
 namespace BC {
 
   //! Boundary condition types
@@ -36,3 +43,65 @@ namespace BC {
   }
 
 } // namespace BC
+
+
+/**
+ * A simple container for boundary cells. You can in principle just use a list
+ * or a vector, but those STL objects are not trivially copyable - something
+ * e.g. openMP offloading is not happy about. So I write proper constructors
+ * by myself.
+ */
+class Boundary{
+
+public:
+
+  size_t _n;
+  Cell** _cells;
+
+  explicit Boundary(const size_t N) : _n(N), _cells(new Cell*[N]) {};
+
+  ~Boundary() {
+    delete[] _cells;
+  }
+
+  // Copy operator
+  Boundary(const Boundary& other) : _n(other._n) {
+    for (size_t i = 0; i < _n; i++)
+      _cells[i] = other._cells[i];
+  }
+
+  // Copy assignment
+  Boundary& operator=(const Boundary& other) {
+    this->_n= other._n;
+    for (size_t i = 0; i < _n; i++)
+      this->_cells[i] = other._cells[i];
+    return *this;
+  }
+
+  // Move operator
+  Boundary(const Boundary&& other)  noexcept : _n(other._n) {
+    _cells = std::move(other._cells);
+  }
+
+  // Move assignment
+  Boundary& operator=(Boundary&& other) noexcept {
+    this->_n= other._n;
+    this->_cells = other._cells;
+    return *this;
+  }
+
+  // overload [] operator
+  Cell*& operator[](size_t index){
+#if DEBUG_LEVEL > 0
+    if (index > _n)
+      error("Invalid index:" + std::to_string(index));
+#endif
+    return _cells[index];
+  }
+
+  size_t size(){
+    return _n;
+  }
+};
+
+

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -12,39 +12,6 @@
 #include "Cell.h"
 
 
-namespace BC {
-
-  //! Boundary condition types
-  enum BoundaryCondition {
-    Periodic     = 0,
-    Reflective   = 1,
-    Transmissive = 2,
-    Undefined,
-    Count
-  };
-
-
-  //! Get a name for your boundary condition.
-  inline const char* getBoundaryConditionName(const enum BoundaryCondition bc) {
-
-    switch (bc) {
-    case BoundaryCondition::Periodic:
-      return "Periodic";
-    case BoundaryCondition::Reflective:
-      return "Reflective";
-    case BoundaryCondition::Transmissive:
-      return "Transmissive";
-    case Count:
-      return "Count";
-    case BoundaryCondition::Undefined:
-    default:
-      return "Undefined";
-    }
-  }
-
-} // namespace BC
-
-
 /**
  * A simple container for boundary cells. Just think of it as an array of
  * pointers to cells.
@@ -113,3 +80,68 @@ public:
     return _n;
   }
 };
+
+
+namespace BC {
+
+  //! Boundary condition types
+  enum BoundaryCondition {
+    Periodic     = 0,
+    Reflective   = 1,
+    Transmissive = 2,
+    Undefined,
+    Count
+  };
+
+
+  //! Get a name for your boundary condition.
+  inline const char* getBoundaryConditionName(const enum BoundaryCondition bc) {
+
+    switch (bc) {
+    case BoundaryCondition::Periodic:
+      return "Periodic";
+    case BoundaryCondition::Reflective:
+      return "Reflective";
+    case BoundaryCondition::Transmissive:
+      return "Transmissive";
+    case Count:
+      return "Count";
+    case BoundaryCondition::Undefined:
+    default:
+      return "Undefined";
+    }
+  }
+
+  //! Convenience alias to use functions which return function pointers.
+  using BoundaryFunctionPtr = void (*)(
+    Boundary&, Boundary&, Boundary&, Boundary&, const size_t, const size_t
+  );
+
+  void periodic(
+    Boundary&    real_left,
+    Boundary&    real_right,
+    Boundary&    ghost_left,
+    Boundary&    ghost_right,
+    const size_t nbc,
+    const size_t dimension
+  );
+
+  void reflective(
+    Boundary&    real_left,
+    Boundary&    real_right,
+    Boundary&    ghost_left,
+    Boundary&    ghost_right,
+    const size_t nbc,
+    const size_t dimension
+  );
+
+  void transmissive(
+    Boundary&    real_left,
+    Boundary&    real_right,
+    Boundary&    ghost_left,
+    Boundary&    ghost_right,
+    const size_t nbc,
+    const size_t dimension
+  );
+
+} // namespace BC

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -411,13 +411,6 @@ std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Gr
 
   size_t nbc = getNBC();
 
-#if DEBUG_LEVEL > 0
-  assert(real_left.size() == nbc);
-  assert(real_right.size() == nbc);
-  assert(ghost_left.size() == nbc);
-  assert(ghost_right.size() == nbc);
-#endif
-
   std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> real2ghost;
 
   switch (getBoundaryType()) {
@@ -430,6 +423,12 @@ std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Gr
         Boundary&    ghost_right,
         const size_t dimension
       ) {
+#if DEBUG_LEVEL > 0
+        assert(real_left.size() == nbc);
+        assert(real_right.size() == nbc);
+        assert(ghost_left.size() == nbc);
+        assert(ghost_right.size() == nbc);
+#endif
         for (size_t i = 0; i < nbc; i++) {
           ghost_left[i]->copyBoundaryData(real_right[i]);
           ghost_right[i]->copyBoundaryData(real_left[i]);
@@ -446,6 +445,12 @@ std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Gr
         Boundary&    ghost_right,
         const size_t dimension
       ) {
+#if DEBUG_LEVEL > 0
+        assert(real_left.size() == nbc);
+        assert(real_right.size() == nbc);
+        assert(ghost_left.size() == nbc);
+        assert(ghost_right.size() == nbc);
+#endif
         for (size_t i = 0; i < nbc; i++) {
           ghost_left[i]->copyBoundaryDataReflective(real_left[real_left.size() - i - 1], dimension);
           ghost_right[i]->copyBoundaryDataReflective(
@@ -464,6 +469,12 @@ std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Gr
         Boundary&    ghost_right,
         const size_t dimension
       ) {
+#if DEBUG_LEVEL > 0
+        assert(real_left.size() == nbc);
+        assert(real_right.size() == nbc);
+        assert(ghost_left.size() == nbc);
+        assert(ghost_right.size() == nbc);
+#endif
         for (size_t i = 0; i < nbc; i++) {
           ghost_left[i]->copyBoundaryData(real_left[real_left.size() - i - 1]);
           ghost_right[i]->copyBoundaryData(real_right[real_right.size() - i - 1]);

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -393,6 +393,9 @@ void Grid::applyBoundaryConditions() {
 /**
  * Selects and returns the function that applied the correct boundary
  * conditions from ghost to real cells.
+ * Originally I had a more elegant solution, but openMP offloading couldn't
+ * handle std::function calls due to the STL's internal exception
+ * handling/throwing. So instead, I had to move to function pointers.
  *
  * The returned function takes 6 parameters, in this order:
  * @param realL:     array of pointers to real cells with lowest index

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -341,10 +341,10 @@ void Grid::applyBoundaryConditions() {
   const size_t lastReal  = getLastCellIndex();
 
   // Make some space.
-  std::vector<Cell*> real_left(nbc);
-  std::vector<Cell*> real_right(nbc);
-  std::vector<Cell*> ghost_left(nbc);
-  std::vector<Cell*> ghost_right(nbc);
+  Boundary real_left(nbc);
+  Boundary real_right(nbc);
+  Boundary ghost_left(nbc);
+  Boundary ghost_right(nbc);
 
   if (Dimensions == 1) {
     for (size_t i = 0; i < firstReal; i++) {
@@ -402,10 +402,10 @@ void Grid::applyBoundaryConditions() {
  * lowest array index is also lowest index of cell in grid
  */
 void Grid::realToGhost(
-  std::vector<Cell*> real_left,
-  std::vector<Cell*> real_right,
-  std::vector<Cell*> ghost_left,
-  std::vector<Cell*> ghost_right,
+  Boundary& real_left,
+  Boundary& real_right,
+  Boundary& ghost_left,
+  Boundary& ghost_right,
   const size_t       dimension
 ) // dimension defaults to 0
 {

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -4,7 +4,6 @@
 #include <iomanip>
 #include <iostream>
 
-#include "BoundaryConditions.h"
 #include "Cell.h"
 #include "Logging.h"
 #include "Parameters.h"
@@ -341,7 +340,7 @@ void Grid::applyBoundaryConditions() {
   const size_t lastReal  = getLastCellIndex();
 
   // Select which BC to use.
-  auto real2ghost = selectBoundaryFunction();
+  BC::BoundaryFunctionPtr real2ghost = selectBoundaryFunction();
 
   // Make some space.
   Boundary real_left(nbc);
@@ -356,7 +355,7 @@ void Grid::applyBoundaryConditions() {
       ghost_left[i]  = &(getCell(i));
       ghost_right[i] = &(getCell(lastReal + i));
     }
-    real2ghost(real_left, real_right, ghost_left, ghost_right, 0);
+    real2ghost(real_left, real_right, ghost_left, ghost_right, nbc, 0);
   }
 
   else if (Dimensions == 2) {
@@ -369,7 +368,7 @@ void Grid::applyBoundaryConditions() {
         ghost_left[i]  = &(getCell(i, j));
         ghost_right[i] = &(getCell(lastReal + i, j));
       }
-      real2ghost(real_left, real_right, ghost_left, ghost_right, 0);
+      real2ghost(real_left, real_right, ghost_left, ghost_right, nbc, 0);
     }
 
     // upper-lower boundaries
@@ -381,7 +380,7 @@ void Grid::applyBoundaryConditions() {
         ghost_left[j]  = &(getCell(i, j));
         ghost_right[j] = &(getCell(i, lastReal + j));
       }
-      real2ghost(real_left, real_right, ghost_left, ghost_right, 1);
+      real2ghost(real_left, real_right, ghost_left, ghost_right, nbc, 1);
     }
   } else {
     error("Not implemented.");
@@ -395,92 +394,29 @@ void Grid::applyBoundaryConditions() {
  * Selects and returns the function that applied the correct boundary
  * conditions from ghost to real cells.
  *
- * The returned function takes 5 parameters, in this order:
+ * The returned function takes 6 parameters, in this order:
  * @param realL:     array of pointers to real cells with lowest index
  * @param realR:     array of pointers to real cells with highest index
  * @param ghostL:    array of pointers to ghost cells with lowest index
  * @param ghostR:    array of pointers to ghost cells with highest index
+ * @param nbc:       number of boundary cells.
  * @param dimension: dimension integer. 0 for x, 1 for y. Needed for
  *                   reflective boundary conditions.
  *
  * All arguments are arrays of size Grid::_nbc (number of boundary cells).
  * Lowest array index is also lowest index of cell in grid.
  */
-std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Grid::
-  selectBoundaryFunction() {
-
-  size_t nbc = getNBC();
-
-  std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> real2ghost;
+BC::BoundaryFunctionPtr Grid::selectBoundaryFunction() {
 
   switch (getBoundaryType()) {
   case BC::BoundaryCondition::Periodic:
-    real2ghost =
-      [=](
-        Boundary&    real_left,
-        Boundary&    real_right,
-        Boundary&    ghost_left,
-        Boundary&    ghost_right,
-        const size_t dimension
-      ) {
-#if DEBUG_LEVEL > 0
-        assert(real_left.size() == nbc);
-        assert(real_right.size() == nbc);
-        assert(ghost_left.size() == nbc);
-        assert(ghost_right.size() == nbc);
-#endif
-        for (size_t i = 0; i < nbc; i++) {
-          ghost_left[i]->copyBoundaryData(real_right[i]);
-          ghost_right[i]->copyBoundaryData(real_left[i]);
-        }
-      };
-    break;
+    return &BC::periodic;
 
   case BC::BoundaryCondition::Reflective:
-    real2ghost =
-      [=](
-        Boundary&    real_left,
-        Boundary&    real_right,
-        Boundary&    ghost_left,
-        Boundary&    ghost_right,
-        const size_t dimension
-      ) {
-#if DEBUG_LEVEL > 0
-        assert(real_left.size() == nbc);
-        assert(real_right.size() == nbc);
-        assert(ghost_left.size() == nbc);
-        assert(ghost_right.size() == nbc);
-#endif
-        for (size_t i = 0; i < nbc; i++) {
-          ghost_left[i]->copyBoundaryDataReflective(real_left[real_left.size() - i - 1], dimension);
-          ghost_right[i]->copyBoundaryDataReflective(
-            real_right[real_right.size() - i - 1], dimension
-          );
-        }
-      };
-    break;
+    return &BC::reflective;
 
   case BC::BoundaryCondition::Transmissive:
-    real2ghost =
-      [=](
-        Boundary&    real_left,
-        Boundary&    real_right,
-        Boundary&    ghost_left,
-        Boundary&    ghost_right,
-        const size_t dimension
-      ) {
-#if DEBUG_LEVEL > 0
-        assert(real_left.size() == nbc);
-        assert(real_right.size() == nbc);
-        assert(ghost_left.size() == nbc);
-        assert(ghost_right.size() == nbc);
-#endif
-        for (size_t i = 0; i < nbc; i++) {
-          ghost_left[i]->copyBoundaryData(real_left[real_left.size() - i - 1]);
-          ghost_right[i]->copyBoundaryData(real_right[real_right.size() - i - 1]);
-        }
-      };
-    break;
+    return &BC::transmissive;
 
   default:
     std::stringstream msg;
@@ -488,10 +424,8 @@ std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Gr
     msg << BC::getBoundaryConditionName(getBoundaryType());
     msg << " not defined.";
     error(msg.str());
-    break;
+    return &BC::periodic;
   }
-
-  return real2ghost;
 }
 
 

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -402,11 +402,11 @@ void Grid::applyBoundaryConditions() {
  * lowest array index is also lowest index of cell in grid
  */
 void Grid::realToGhost(
-  Boundary& real_left,
-  Boundary& real_right,
-  Boundary& ghost_left,
-  Boundary& ghost_right,
-  const size_t       dimension
+  Boundary&    real_left,
+  Boundary&    real_right,
+  Boundary&    ghost_left,
+  Boundary&    ghost_right,
+  const size_t dimension
 ) // dimension defaults to 0
 {
 

--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -406,8 +406,8 @@ void Grid::applyBoundaryConditions() {
  * All arguments are arrays of size Grid::_nbc (number of boundary cells).
  * Lowest array index is also lowest index of cell in grid.
  */
-std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)>
-Grid::selectBoundaryFunction() {
+std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)> Grid::
+  selectBoundaryFunction() {
 
   size_t nbc = getNBC();
 
@@ -422,12 +422,14 @@ Grid::selectBoundaryFunction() {
 
   switch (getBoundaryType()) {
   case BC::BoundaryCondition::Periodic:
-    real2ghost = [=](
-      Boundary&    real_left,
-      Boundary&    real_right,
-      Boundary&    ghost_left,
-      Boundary&    ghost_right,
-      const size_t dimension){
+    real2ghost =
+      [=](
+        Boundary&    real_left,
+        Boundary&    real_right,
+        Boundary&    ghost_left,
+        Boundary&    ghost_right,
+        const size_t dimension
+      ) {
         for (size_t i = 0; i < nbc; i++) {
           ghost_left[i]->copyBoundaryData(real_right[i]);
           ghost_right[i]->copyBoundaryData(real_left[i]);
@@ -436,26 +438,32 @@ Grid::selectBoundaryFunction() {
     break;
 
   case BC::BoundaryCondition::Reflective:
-    real2ghost = [=](
-      Boundary&    real_left,
-      Boundary&    real_right,
-      Boundary&    ghost_left,
-      Boundary&    ghost_right,
-      const size_t dimension){
-      for (size_t i = 0; i < nbc; i++) {
-        ghost_left[i]->copyBoundaryDataReflective(real_left[real_left.size() - i - 1], dimension);
-        ghost_right[i]->copyBoundaryDataReflective(real_right[real_right.size() - i - 1], dimension);
-      }
-    };
+    real2ghost =
+      [=](
+        Boundary&    real_left,
+        Boundary&    real_right,
+        Boundary&    ghost_left,
+        Boundary&    ghost_right,
+        const size_t dimension
+      ) {
+        for (size_t i = 0; i < nbc; i++) {
+          ghost_left[i]->copyBoundaryDataReflective(real_left[real_left.size() - i - 1], dimension);
+          ghost_right[i]->copyBoundaryDataReflective(
+            real_right[real_right.size() - i - 1], dimension
+          );
+        }
+      };
     break;
 
   case BC::BoundaryCondition::Transmissive:
-    real2ghost = [=](
-      Boundary&    real_left,
-      Boundary&    real_right,
-      Boundary&    ghost_left,
-      Boundary&    ghost_right,
-      const size_t dimension){
+    real2ghost =
+      [=](
+        Boundary&    real_left,
+        Boundary&    real_right,
+        Boundary&    ghost_left,
+        Boundary&    ghost_right,
+        const size_t dimension
+      ) {
         for (size_t i = 0; i < nbc; i++) {
           ghost_left[i]->copyBoundaryData(real_left[real_left.size() - i - 1]);
           ghost_right[i]->copyBoundaryData(real_right[real_right.size() - i - 1]);

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -96,11 +96,11 @@ public:
 
   //! Apply the boundary conditions from real to ghost cells.
   void realToGhost(
-    Boundary& real_left,
-    Boundary& real_right,
-    Boundary& ghost_left,
-    Boundary& ghost_right,
-    const size_t       dimension = 0
+    Boundary&    real_left,
+    Boundary&    real_right,
+    Boundary&    ghost_left,
+    Boundary&    ghost_right,
+    const size_t dimension = 0
   );
 
 

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vector>
-
 #include "Cell.h"
 #include "Logging.h"
 #include "Parameters.h"
@@ -98,10 +96,10 @@ public:
 
   //! Apply the boundary conditions from real to ghost cells.
   void realToGhost(
-    std::vector<Cell*> real_left,
-    std::vector<Cell*> real_right,
-    std::vector<Cell*> ghost_left,
-    std::vector<Cell*> ghost_right,
+    Boundary& real_left,
+    Boundary& real_right,
+    Boundary& ghost_left,
+    Boundary& ghost_right,
     const size_t       dimension = 0
   );
 

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -97,8 +97,9 @@ public:
 
 
   //! Get the function that applies the correct boundary conditions.
-  std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)>
-  selectBoundaryFunction();
+  std::function<void(
+    Boundary&, Boundary&, Boundary&, Boundary&, const size_t
+  )> selectBoundaryFunction();
 
 
   //! Print out the grid.

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "Cell.h"
 #include "Logging.h"
 #include "Parameters.h"
@@ -94,14 +96,9 @@ public:
   void applyBoundaryConditions();
 
 
-  //! Apply the boundary conditions from real to ghost cells.
-  void realToGhost(
-    Boundary&    real_left,
-    Boundary&    real_right,
-    Boundary&    ghost_left,
-    Boundary&    ghost_right,
-    const size_t dimension = 0
-  );
+  //! Get the function that applies the correct boundary conditions.
+  std::function<void(Boundary&, Boundary&, Boundary&, Boundary&, const size_t)>
+  selectBoundaryFunction();
 
 
   //! Print out the grid.

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <functional>
-
+#include "BoundaryConditions.h"
 #include "Cell.h"
 #include "Logging.h"
 #include "Parameters.h"
@@ -97,9 +96,7 @@ public:
 
 
   //! Get the function that applies the correct boundary conditions.
-  std::function<void(
-    Boundary&, Boundary&, Boundary&, Boundary&, const size_t
-  )> selectBoundaryFunction();
+  BC::BoundaryFunctionPtr selectBoundaryFunction();
 
 
   //! Print out the grid.


### PR DESCRIPTION
Address sanitizer is handy, but not particularly related to the AMD hackathon/parallelisation.

I removed the std::vectors<Cell*> because openMP was unhappy with them - they're not trivially copyable. So instead I wrote a simple container class myself.